### PR TITLE
Changed method name run_on_change after upgrade of Guard

### DIFF
--- a/lib/guard/shell.rb
+++ b/lib/guard/shell.rb
@@ -18,7 +18,7 @@ module Guard
     end
 
     # Print the result of the command(s), if there are results to be printed.
-    def run_on_change(res)
+    def run_on_changes(res)
       puts res if res
     end
 


### PR DESCRIPTION
Since Guard version 1.1.0 the method "run_on_change" is deprecated. You have to use "run_on_changes".
