### PR TITLE
Run on modifications instead of changes

### DIFF
--- a/lib/guard/shell.rb
+++ b/lib/guard/shell.rb
@@ -14,11 +14,11 @@ module Guard
 
     # Call #run_on_change for all files which match this guard.
     def run_all
-      run_on_changes(Watcher.match_files(self, Dir.glob('{,**/}*{,.*}').uniq))
+      run_on_modifications(Watcher.match_files(self, Dir.glob('{,**/}*{,.*}').uniq))
     end
 
     # Print the result of the command(s), if there are results to be printed.
-    def run_on_changes(res)
+    def run_on_modifications(res)
       puts res if res
     end
 

--- a/lib/guard/shell/templates/Guardfile
+++ b/lib/guard/shell/templates/Guardfile
@@ -1,6 +1,6 @@
 # Add files and commands to this file, like the example:
 #   watch(%r{file/path}) { `command(s)` }
 #
-guard 'shell' do
+guard :shell do
   watch(/(.*).txt/) {|m| `tail #{m[0]}` }
 end


### PR DESCRIPTION
Due to the way vim (or other editors) saves files,
guard-shell executes twice or three times. To prevent this,
use run_on_modifications instead of run_on_changes.

See also:
- guard/guard#297
- guard/guard#495
