### PR TITLE
Defined a method to make callbacks working

### DIFF
--- a/lib/guard/shell.rb
+++ b/lib/guard/shell.rb
@@ -11,7 +11,7 @@ module Guard
       run_all if options[:all_on_start]
     end
 
-    # Defined only for make callback(:stop_begin) and callback(:stop_end) working
+    # Defined only to make callback(:stop_begin) and callback(:stop_end) working
     def stop
     end
 


### PR DESCRIPTION
see https://github.com/guard/guard/wiki/Hooks-and-callbacks

before this modify, callback(:stop_begin) and callback(:stop_end) didn't work.

This is useful if you want to execute some code when guard is exiting.
