### PR TITLE
avoid using deprecated Guard::Guard (guard/guard)

### DIFF
--- a/guard-shell.gemspec
+++ b/guard-shell.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
     modified.
   DESC
 
-  s.add_dependency 'guard', '>= 1.1.0'
+  s.add_dependency 'guard', '>= 2.0.0'
 
   s.files        = %w(Readme.md LICENSE)
   s.files       += Dir["{lib}/**/*"]

--- a/lib/guard/shell.rb
+++ b/lib/guard/shell.rb
@@ -1,10 +1,9 @@
 require 'guard'
-require 'guard/guard'
-require 'guard/watcher'
+require 'guard/plugin'
 require 'guard/shell/version'
 
 module Guard
-  class Shell < Guard
+  class Shell < Plugin
 
     # Calls #run_all if the :all_on_start option is present.
     def start


### PR DESCRIPTION
Guard 2.8.0 now shows a big deprecation warning when requiring `guard/guard.rb`.

(https://github.com/guard/guard/releases/tag/v2.8.0)
